### PR TITLE
Prem/feat/get report

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,16 +4,18 @@ import { LoggerMiddleware } from "./common/middleware/logger.middleware"
 import { AccountModule } from "./modules/account/account.module"
 import { AuthModule } from "./modules/auth/auth.module"
 import { ConfigModule } from "@nestjs/config"
+import { ReportModule } from "./modules/report/report.module"
 import { ReviewModule } from "./modules/review/review.module"
 import appConfig from "./config/app.config"
 import corsConfig from "./config/cors.config"
-import { AvailabilityModule } from './modules/prophet/availability/availability.module';
+import { AvailabilityModule } from "./modules/prophet/availability/availability.module"
 
 @Module({
   imports: [
     AuthModule,
     PrismaModule,
     AccountModule,
+    ReportModule,
     ReviewModule,
     ConfigModule.forRoot({
       isGlobal: true,

--- a/src/modules/account/account.service.ts
+++ b/src/modules/account/account.service.ts
@@ -80,7 +80,11 @@ export class AccountService {
       if (isPublic) {
         return { ...base, role: Role.CUSTOMER, ...customer }
       } else {
-        return { username: base.username, profileUrl: base.profileUrl }
+        return {
+          username: base.username,
+          profileUrl: base.profileUrl,
+          role: Role.CUSTOMER,
+        }
       }
     }
     if (account.role === Role.PROPHET) {

--- a/src/modules/account/dto/get-account.dto.ts
+++ b/src/modules/account/dto/get-account.dto.ts
@@ -29,6 +29,9 @@ export class CustomerAccountDto extends BaseAccountDto {
 
   @ApiPropertyOptional()
   birthTime?: Date | null
+
+  @ApiPropertyOptional()
+  role?: string | null
 }
 
 export class ProphetAccountDto extends BaseAccountDto {
@@ -49,6 +52,9 @@ export class LimitedCustomerAccountDto {
 
   @ApiPropertyOptional()
   profileUrl?: string | null
+
+  @ApiPropertyOptional()
+  role?: string | null
 }
 
 export type AccountResponseDto =

--- a/src/modules/customer/customer.repository.ts
+++ b/src/modules/customer/customer.repository.ts
@@ -19,6 +19,17 @@ export class CustomerRepository {
       select,
     })
   }
+
+  findByCustomerId<S extends Prisma.CustomerSelect>(
+    id: string,
+    select: S
+  ): Promise<Prisma.CustomerGetPayload<{ select: S }> | null> {
+    return this.prisma.customer.findUnique({
+      where: { id },
+      select,
+    })
+  }
+
   async createCustomerDetail(
     zodiacSign: ZodiacSign,
     birthDate: string,

--- a/src/modules/customer/customer.service.ts
+++ b/src/modules/customer/customer.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from "@nestjs/common"
 import { CustomerRepository } from "./customer.repository"
-import { CustomerBasic, CustomerDetail } from "./interface/customer.interface"
+import {
+  CustomerBasic,
+  CustomerDetail,
+  CustomerAccount,
+} from "./interface/customer.interface"
 import { ZodiacSign } from "@prisma/client"
 
 @Injectable()
@@ -30,12 +34,12 @@ export class CustomerService {
     return { id: customer?.id, isPublic: customer?.isPublic }
   }
 
-  async getCustomerByCustomerId(customerId: string): Promise<CustomerBasic> {
+  async getAccountByCustomerId(customerId: string): Promise<CustomerAccount> {
     const customer = await this.repo.findByCustomerId(customerId, {
       id: true,
-      isPublic: true,
+      accountId: true,
     })
-    return { id: customer?.id, isPublic: customer?.isPublic }
+    return { id: customer?.id, accountId: customer?.accountId }
   }
 
   async createDetail(

--- a/src/modules/customer/customer.service.ts
+++ b/src/modules/customer/customer.service.ts
@@ -21,6 +21,7 @@ export class CustomerService {
       isPublic: customer?.isPublic,
     }
   }
+
   async getCustomerByAccountId(accountId: string): Promise<CustomerBasic> {
     const customer = await this.repo.findByAccountId(accountId, {
       id: true,
@@ -28,6 +29,15 @@ export class CustomerService {
     })
     return { id: customer?.id, isPublic: customer?.isPublic }
   }
+
+  async getCustomerByCustomerId(customerId: string): Promise<CustomerBasic> {
+    const customer = await this.repo.findByCustomerId(customerId, {
+      id: true,
+      isPublic: true,
+    })
+    return { id: customer?.id, isPublic: customer?.isPublic }
+  }
+
   async createDetail(
     accountId: string,
     dto: { zodiacSign: ZodiacSign; birthDate: string; birthTime: string }

--- a/src/modules/customer/interface/customer.interface.ts
+++ b/src/modules/customer/interface/customer.interface.ts
@@ -9,3 +9,8 @@ export interface CustomerBasic {
   id?: string | null
   isPublic?: boolean | null
 }
+
+export interface CustomerAccount {
+  id?: string | null
+  accountId?: string | null
+}

--- a/src/modules/report/dto/get-report.dto.ts
+++ b/src/modules/report/dto/get-report.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger"
+
+export class ReportDto {
+  @ApiProperty()
+  customer!: string
+
+  @ApiPropertyOptional()
+  admin?: string | null
+
+  @ApiProperty()
+  reportType!: string
+
+  @ApiProperty()
+  topic!: string
+
+  @ApiProperty()
+  description!: string
+
+  @ApiProperty()
+  reportStatus!: string
+}
+
+export class GetReportsResponseDto {
+  @ApiProperty({ type: [ReportDto] })
+  reports!: ReportDto[]
+}

--- a/src/modules/report/dto/get-report.dto.ts
+++ b/src/modules/report/dto/get-report.dto.ts
@@ -4,6 +4,12 @@ export class ReportDto {
   @ApiProperty()
   customer!: string
 
+  @ApiProperty()
+  createdAt!: Date | null
+
+  @ApiPropertyOptional()
+  profileUrl?: string | null
+
   @ApiPropertyOptional()
   admin?: string | null
 

--- a/src/modules/report/report.controller.ts
+++ b/src/modules/report/report.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Param } from "@nestjs/common"
 import { ApiOkResponse, ApiTags } from "@nestjs/swagger"
 import { ReportService } from "./report.service"
-import { GetReportsResponseDto } from "./dto/get-report.dto"
+import { ReportDto, GetReportsResponseDto } from "./dto/get-report.dto"
 
 @ApiTags("report")
 @Controller("report")
@@ -16,20 +16,44 @@ export class ReportController {
     return this.service.getAllReports()
   }
 
+  @Get(":id")
+  @ApiOkResponse({
+    type: GetReportsResponseDto,
+  })
+  getById(@Param("id") id: string): Promise<ReportDto> {
+    return this.service.getReportById(id)
+  }
+
   @Get("me")
   @ApiOkResponse({
     type: GetReportsResponseDto,
   })
   get(): Promise<GetReportsResponseDto> {
     const tmpcustomerId = "3ad80e2e4bdc4b7a"
-    return this.service.getReportByCustomerId(tmpcustomerId)
+    return this.service.getReportByAccountId(tmpcustomerId)
   }
 
   @Get("account/:id")
   @ApiOkResponse({
     type: GetReportsResponseDto,
   })
-  getById(@Param("id") id: string): Promise<GetReportsResponseDto> {
+  getByAccountId(@Param("id") id: string): Promise<GetReportsResponseDto> {
+    return this.service.getReportByAccountId(id)
+  }
+
+  @Get("customer/:id")
+  @ApiOkResponse({
+    type: GetReportsResponseDto,
+  })
+  getByCustomerId(@Param("id") id: string): Promise<GetReportsResponseDto> {
     return this.service.getReportByCustomerId(id)
+  }
+
+  @Get("admin/:id")
+  @ApiOkResponse({
+    type: GetReportsResponseDto,
+  })
+  getByAdminId(@Param("id") id: string): Promise<GetReportsResponseDto> {
+    return this.service.getReportByAccountId(id)
   }
 }

--- a/src/modules/report/report.controller.ts
+++ b/src/modules/report/report.controller.ts
@@ -1,0 +1,35 @@
+import { Controller, Get, Param } from "@nestjs/common"
+import { ApiOkResponse, ApiTags } from "@nestjs/swagger"
+import { ReportService } from "./report.service"
+import { GetReportsResponseDto } from "./dto/get-report.dto"
+
+@ApiTags("report")
+@Controller("report")
+export class ReportController {
+  constructor(private readonly service: ReportService) {}
+
+  @Get()
+  @ApiOkResponse({
+    type: GetReportsResponseDto,
+  })
+  getAll(): Promise<GetReportsResponseDto> {
+    return this.service.getAllReports()
+  }
+
+  @Get("me")
+  @ApiOkResponse({
+    type: GetReportsResponseDto,
+  })
+  get(): Promise<GetReportsResponseDto> {
+    const tmpcustomerId = "3ad80e2e4bdc4b7a"
+    return this.service.getReportByCustomerId(tmpcustomerId)
+  }
+
+  @Get("account/:id")
+  @ApiOkResponse({
+    type: GetReportsResponseDto,
+  })
+  getById(@Param("id") id: string): Promise<GetReportsResponseDto> {
+    return this.service.getReportByCustomerId(id)
+  }
+}

--- a/src/modules/report/report.module.ts
+++ b/src/modules/report/report.module.ts
@@ -3,11 +3,10 @@ import { ReportController } from "./report.controller"
 import { ReportService } from "./report.service"
 import { ReportRepository } from "./report.repository"
 import { CustomerModule } from "../customer/customer.module"
-
-// ? admin
+import { AccountModule } from "../account/account.module"
 
 @Module({
-  imports: [CustomerModule],
+  imports: [CustomerModule, AccountModule],
   controllers: [ReportController],
   providers: [ReportService, ReportRepository],
   exports: [ReportService],

--- a/src/modules/report/report.module.ts
+++ b/src/modules/report/report.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common"
+import { ReportController } from "./report.controller"
+import { ReportService } from "./report.service"
+import { ReportRepository } from "./report.repository"
+import { CustomerModule } from "../customer/customer.module"
+
+// ? admin
+
+@Module({
+  imports: [CustomerModule],
+  controllers: [ReportController],
+  providers: [ReportService, ReportRepository],
+  exports: [ReportService],
+})
+export class ReportModule {}

--- a/src/modules/report/report.repository.ts
+++ b/src/modules/report/report.repository.ts
@@ -1,0 +1,54 @@
+import { Injectable } from "@nestjs/common"
+import { PrismaService } from "../../db/prisma.service"
+
+@Injectable()
+export class ReportRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findAll(): Promise<
+    Array<{
+      customerId: string
+      adminId: string | null
+      reportType: string
+      topic: string
+      description: string
+      reportStatus: string
+    }>
+  > {
+    return this.prisma.report.findMany({
+      select: {
+        customerId: true,
+        adminId: true,
+        reportType: true,
+        topic: true,
+        description: true,
+        reportStatus: true,
+      },
+    })
+  }
+
+  findByCustomerId(customerId: string): Promise<
+    Array<{
+      customerId: string
+      adminId: string | null
+      reportType: string
+      topic: string
+      description: string
+      reportStatus: string
+    }>
+  > {
+    return this.prisma.report.findMany({
+      where: {
+        customerId: customerId,
+      },
+      select: {
+        customerId: true,
+        adminId: true,
+        reportType: true,
+        topic: true,
+        description: true,
+        reportStatus: true,
+      },
+    })
+  }
+}

--- a/src/modules/report/report.repository.ts
+++ b/src/modules/report/report.repository.ts
@@ -8,6 +8,8 @@ export class ReportRepository {
   findAll(): Promise<
     Array<{
       customerId: string
+      customer: { accountId: string }
+      createdAt: Date | null
       adminId: string | null
       reportType: string
       topic: string
@@ -18,11 +20,42 @@ export class ReportRepository {
     return this.prisma.report.findMany({
       select: {
         customerId: true,
+        customer: {
+          select: {
+            accountId: true,
+          },
+        },
         adminId: true,
         reportType: true,
         topic: true,
         description: true,
         reportStatus: true,
+        createdAt: true,
+      },
+    })
+  }
+
+  findById(reportId: string): Promise<{
+    customerId: string
+    createdAt: Date | null
+    adminId: string | null
+    reportType: string
+    topic: string
+    description: string
+    reportStatus: string
+  } | null> {
+    return this.prisma.report.findUnique({
+      where: {
+        id: reportId,
+      },
+      select: {
+        customerId: true,
+        adminId: true,
+        reportType: true,
+        topic: true,
+        description: true,
+        reportStatus: true,
+        createdAt: true,
       },
     })
   }
@@ -30,6 +63,7 @@ export class ReportRepository {
   findByCustomerId(customerId: string): Promise<
     Array<{
       customerId: string
+      createdAt: Date | null
       adminId: string | null
       reportType: string
       topic: string
@@ -48,6 +82,34 @@ export class ReportRepository {
         topic: true,
         description: true,
         reportStatus: true,
+        createdAt: true,
+      },
+    })
+  }
+
+  findByAdminId(adminId: string): Promise<
+    Array<{
+      customerId: string
+      createdAt: Date | null
+      adminId: string | null
+      reportType: string
+      topic: string
+      description: string
+      reportStatus: string
+    }>
+  > {
+    return this.prisma.report.findMany({
+      where: {
+        adminId: adminId,
+      },
+      select: {
+        customerId: true,
+        adminId: true,
+        reportType: true,
+        topic: true,
+        description: true,
+        reportStatus: true,
+        createdAt: true,
       },
     })
   }

--- a/src/modules/report/report.service.ts
+++ b/src/modules/report/report.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import { ReportRepository } from "./report.repository"
+import { CustomerService } from "../customer/customer.service"
+import { GetReportsResponseDto } from "./dto/get-report.dto"
+
+@Injectable()
+export class ReportService {
+  constructor(
+    private readonly repo: ReportRepository,
+    private readonly customerService: CustomerService
+  ) {}
+
+  async getAllReports(): Promise<GetReportsResponseDto> {
+    const reportData = await this.repo.findAll()
+    const reports = reportData.map(r => ({
+      customer: r.customerId,
+      admin: r.adminId,
+      reportType: r.reportType,
+      topic: r.topic,
+      description: r.description,
+      reportStatus: r.reportStatus,
+    }))
+    return { reports }
+  }
+
+  async getReportByCustomerId(
+    customerId: string
+  ): Promise<GetReportsResponseDto> {
+    const customer =
+      await this.customerService.getCustomerByCustomerId(customerId)
+    if (!customer?.id) {
+      throw new NotFoundException("Customer not found" + customerId)
+    }
+
+    //Todo: add validate own account
+    if (customer.isPublic) {
+      const reportData = await this.repo.findByCustomerId(customer.id)
+      const reports = reportData.map(r => ({
+        customer: r.customerId,
+        admin: r.adminId,
+        reportType: r.reportType,
+        topic: r.topic,
+        description: r.description,
+        reportStatus: r.reportStatus,
+      }))
+      return { reports }
+    } else {
+      return { reports: [] }
+    }
+  }
+}

--- a/src/modules/report/report.service.ts
+++ b/src/modules/report/report.service.ts
@@ -1,51 +1,169 @@
 import { Injectable, NotFoundException } from "@nestjs/common"
 import { ReportRepository } from "./report.repository"
 import { CustomerService } from "../customer/customer.service"
-import { GetReportsResponseDto } from "./dto/get-report.dto"
+import { AccountService } from "../account/account.service"
+import { ReportDto, GetReportsResponseDto } from "./dto/get-report.dto"
+import { Role } from "@prisma/client"
 
 @Injectable()
 export class ReportService {
   constructor(
     private readonly repo: ReportRepository,
-    private readonly customerService: CustomerService
+    private readonly customerService: CustomerService,
+    private readonly accountService: AccountService
   ) {}
 
   async getAllReports(): Promise<GetReportsResponseDto> {
     const reportData = await this.repo.findAll()
-    const reports = reportData.map(r => ({
-      customer: r.customerId,
-      admin: r.adminId,
-      reportType: r.reportType,
-      topic: r.topic,
-      description: r.description,
-      reportStatus: r.reportStatus,
-    }))
+    const reports = await Promise.all(
+      reportData.map(async r => {
+        const customer = await this.customerService.getAccountByCustomerId(
+          r.customerId
+        )
+        if (!customer?.id) {
+          throw new NotFoundException("Customer not found")
+        }
+        const accountId = customer.accountId
+        if (!accountId) {
+          throw new NotFoundException("Account not found")
+        }
+        const accountData = await this.accountService.getAccountById(accountId)
+
+        return {
+          customer: accountData.username,
+          createdAt: r.createdAt,
+          profileUrl: accountData.profileUrl,
+          admin: r.adminId,
+          reportType: r.reportType,
+          topic: r.topic,
+          description: r.description,
+          reportStatus: r.reportStatus,
+        }
+      })
+    )
+
     return { reports }
+  }
+
+  async getReportById(reportId: string): Promise<ReportDto> {
+    const reportData = await this.repo.findById(reportId)
+    if (!reportData) {
+      throw new NotFoundException("Report not found")
+    }
+    const customer = await this.customerService.getAccountByCustomerId(
+      reportData.customerId
+    )
+    if (!customer?.id) {
+      throw new NotFoundException("Customer not found")
+    }
+    const accountId = customer.accountId
+    if (!accountId) {
+      throw new NotFoundException("Account not found")
+    }
+
+    const accountData = await this.accountService.getAccountById(accountId)
+
+    const report = {
+      customer: accountData.username,
+      admin: reportData.adminId,
+      reportType: reportData.reportType,
+      topic: reportData.topic,
+      description: reportData.description,
+      reportStatus: reportData.reportStatus,
+      profileUrl: accountData.profileUrl,
+      createdAt: reportData.createdAt,
+    }
+    return report
+  }
+
+  async getReportByAccountId(
+    accountId: string
+  ): Promise<GetReportsResponseDto> {
+    const accountData = await this.accountService.getAccountById(accountId)
+    if (!accountData) {
+      throw new NotFoundException("Account not found")
+    }
+    const role = accountData.role
+    if (!role) {
+      throw new NotFoundException("Role not found")
+    }
+
+    if (role === Role.CUSTOMER) {
+      const customer =
+        await this.customerService.getCustomerByAccountId(accountId)
+      if (!customer?.id) {
+        throw new NotFoundException("Customer not found")
+      }
+      const reportData = await this.repo.findByCustomerId(customer.id)
+      const reports = reportData.map(r => ({
+        customer: accountData.username,
+        admin: r.adminId,
+        reportType: r.reportType,
+        topic: r.topic,
+        description: r.description,
+        reportStatus: r.reportStatus,
+        profileUrl: accountData.profileUrl ?? null,
+        createdAt: r.createdAt,
+      }))
+      return { reports }
+    } else if (role === Role.ADMIN) {
+      const reportData = await this.repo.findByAdminId(accountId)
+
+      const reports = await Promise.all(
+        reportData.map(async r => {
+          const customer = await this.customerService.getAccountByCustomerId(
+            r.customerId
+          )
+          if (!customer?.accountId) {
+            throw new NotFoundException("Customer not found")
+          }
+          const custAccount = await this.accountService.getAccountById(
+            customer.accountId
+          )
+
+          return {
+            customer: custAccount?.username ?? "Unknown",
+            admin: accountData.username,
+            reportType: r.reportType,
+            topic: r.topic,
+            description: r.description,
+            reportStatus: r.reportStatus,
+            profileUrl: custAccount?.profileUrl ?? null,
+            createdAt: r.createdAt,
+          }
+        })
+      )
+
+      return { reports }
+    }
+    throw new NotFoundException("neither Customer nor Admin")
   }
 
   async getReportByCustomerId(
     customerId: string
   ): Promise<GetReportsResponseDto> {
     const customer =
-      await this.customerService.getCustomerByCustomerId(customerId)
+      await this.customerService.getAccountByCustomerId(customerId)
     if (!customer?.id) {
-      throw new NotFoundException("Customer not found" + customerId)
+      throw new NotFoundException("Customer not found")
     }
+    const accountId = customer.accountId
+    if (!accountId) {
+      throw new NotFoundException("Account not found")
+    }
+    const accountData = await this.accountService.getAccountById(accountId)
+    const reportData = await this.repo.findByCustomerId(customerId)
 
-    //Todo: add validate own account
-    if (customer.isPublic) {
-      const reportData = await this.repo.findByCustomerId(customer.id)
-      const reports = reportData.map(r => ({
-        customer: r.customerId,
-        admin: r.adminId,
-        reportType: r.reportType,
-        topic: r.topic,
-        description: r.description,
-        reportStatus: r.reportStatus,
-      }))
-      return { reports }
-    } else {
-      return { reports: [] }
-    }
+    const reports = reportData.map(r => ({
+      customer: accountData.username,
+      admin: r.adminId,
+      reportType: r.reportType,
+      topic: r.topic,
+      description: r.description,
+      reportStatus: r.reportStatus,
+      profileUrl: accountData.profileUrl,
+      createdAt: r.createdAt,
+    }))
+    return { reports }
   }
 }


### PR DESCRIPTION
## Report Module
- Added endpoints:
  - GET /report              → list all reports
  - GET /report/:id          → get a single report by ID
  - GET /report/me           → get reports for the current logged-in account
  - GET /report/account/:accountId
  - GET /report/customer/:customerId
  - GET /report/admin/:adminId

## Other Modules
- **Account Module**
  - `getAccountById` now returns the `role` field.
- **Customer Module**
  - Added `getAccountByCustomerId` and related methods (`findByCustomerId`, interface `CustomerAccount`), Because report table record customerId as CustomerId not accountId
