### PR TITLE
fix: auth

### DIFF
--- a/src/modules/account/account.controller.ts
+++ b/src/modules/account/account.controller.ts
@@ -12,6 +12,7 @@ import {
   ApiExtraModels,
   getSchemaPath,
   ApiBody,
+  ApiBearerAuth,
 } from "@nestjs/swagger"
 import {
   BaseRegisterDto,
@@ -45,6 +46,7 @@ export class AccountController {
       ],
     },
   })
+  @ApiBearerAuth()
   get(@CurrentUser("id") id: string): Promise<AccountResponseDto> {
     return this.service.getMyAccount(id)
   }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -7,7 +7,7 @@ import {
   RequestResetPasswordDto,
   ConfirmResetPasswordDto,
 } from "./dto/reset-password.dto"
-import { ApiOkResponse, ApiTags } from "@nestjs/swagger"
+import { ApiBearerAuth, ApiOkResponse, ApiTags } from "@nestjs/swagger"
 import { Public } from "@/common/decorators/public.decorator"
 
 @ApiTags("auth")
@@ -19,6 +19,7 @@ export class AuthController {
   @Post("login")
   @HttpCode(HttpStatus.OK)
   @ApiOkResponse({ type: LoginResponseDto })
+  @ApiBearerAuth()
   async login(@Body() body: LoginRequestDto): Promise<LoginResponseDto> {
     return this.auth.login(body.username, body.password)
   }


### PR DESCRIPTION
This pull request adds authentication documentation improvements to both the account and authentication controllers by annotating key endpoints with the `@ApiBearerAuth()` decorator. This ensures that Swagger/OpenAPI documentation correctly indicates that these endpoints require bearer token authentication.

**Swagger authentication documentation enhancements:**

* Added `@ApiBearerAuth()` decorator to the `get` method in `AccountController` to indicate that this endpoint requires bearer token authentication.
* Imported `ApiBearerAuth` from `@nestjs/swagger` in `account.controller.ts` to support the new decorator.
* Added `@ApiBearerAuth()` decorator to the `login` method in `AuthController` to clarify authentication requirements in Swagger docs.
* Imported `ApiBearerAuth` from `@nestjs/swagger` in `auth.controller.ts` to enable the decorator usage.